### PR TITLE
fix: add tokenizer for the query string

### DIFF
--- a/lunr-repro.tsx
+++ b/lunr-repro.tsx
@@ -93,13 +93,6 @@ const Search: React.FC<{
   query: string;
   docs: Record<string, string>;
 }> = function ({ query, docs }) {
-  // example input = 標準製品
-  // in Japanese these are two words, 標準 and 製品. Which will be tokenized in the docs as such (separated).
-  // in order to search for 標準製品. Use the same tokenizer, to separate the query.
-  // create a tokenized query, which should use the function to tokenize the doc
-  const queryTokenized = lunr.ja.tokenizer(query);
-  // turn the array back into proper lunr query search term. such as "標準 製品"
-  const queryTerm = queryTokenized.join(" ");
   const lunrIndex = useMemo(
     () =>
       lunr(function () {
@@ -115,6 +108,13 @@ const Search: React.FC<{
   );
 
   const [results, error] = useMemo(() => {
+    // example input = 標準製品
+    // in Japanese these are two words, 標準 and 製品. Which will be tokenized in the docs as such (separated).
+    // in order to search for 標準製品. Use the same tokenizer, to separate the query.
+    // create a tokenized query, which should use the function to tokenize the doc
+    const queryTokenized = lunr.ja.tokenizer(query);
+    // turn the array back into proper lunr query search term. such as "標準 製品"
+    const queryTerm = queryTokenized.join(" ");
     try {
       return [lunrIndex.search(queryTerm) ?? [], null];
     } catch (e) {

--- a/lunr-repro.tsx
+++ b/lunr-repro.tsx
@@ -93,19 +93,30 @@ const Search: React.FC<{
   query: string;
   docs: Record<string, string>;
 }> = function ({ query, docs }) {
-  const lunrIndex = useMemo((() => lunr(function () {
-    this.ref('name');
-    this.field('body');
-    for (const [name, body] of Object.entries(docs)) {
-      this.use((lunr as any).ja);
-      this.add({ name, body });
-    }
-    //console.debug(`Indexed ${docs.length} docs`);
-  })), [docs]);
+  // example input = 標準製品
+  // in Japanese these are two words, 標準 and 製品. Which will be tokenized in the docs as such (separated).
+  // in order to search for 標準製品. Use the same tokenizer, to separate the query.
+  // create a tokenized query, which should use the function to tokenize the doc
+  const queryTokenized = lunr.ja.tokenizer(query);
+  // turn the array back into proper lunr query search term. such as "標準 製品"
+  const queryTerm = queryTokenized.join(" ");
+  const lunrIndex = useMemo(
+    () =>
+      lunr(function () {
+        this.use((lunr as any).ja);
+        this.ref("name");
+        this.field("body");
+        for (const [name, body] of Object.entries(docs)) {
+          this.add({ name, body });
+        }
+        //console.debug(`Indexed ${docs.length} docs`);
+      }),
+    [docs]
+  );
 
   const [results, error] = useMemo(() => {
     try {
-      return [lunrIndex.search(query) ?? [], null];
+      return [lunrIndex.search(queryTerm) ?? [], null];
     } catch (e) {
       return [[], `${e.message}`];
     }


### PR DESCRIPTION
Problem: lunr query search term depends on spaces for each token. However, lunr.ja plugin tokenize the fields (documents) using japanese segmenter. 

So, for example the resulting token created for the field 標準製品仕様は will be 標準, 製品, 仕様, and は (as demonstraded in http://chasen.org/~taku/software/TinySegmenter/)

Solution: To search for 標準製品 (which is two words), tokenize the input query using the same tokenizer. Then convert it back into lunr query search term.

Limitation: since this method essentially add spaces to Japanese words (as dictated by the segmenter used by lunr.ja). Using wildcards, fuzzy, boosts (https://lunrjs.com/guides/searching.html) in search method would produce false result. 